### PR TITLE
force ssl in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
@@ -97,5 +97,5 @@ config.action_mailer.delivery_method = :smtp
   #:openssl_verify_mode  => 'none'
   }
 
-    config.action_mailer.default_url_options = { host: 'https://sama-dc-intranet.herokuapp.com' }
+    config.action_mailer.default_url_options = { host: 'samadcintranet.samasource.org' }
 end


### PR DESCRIPTION
The plan is allow the app to have a samasource sub domain. And given that the app shares user sensitive data, it is important to ensure such sharing happens over a secured network. 

#### Updates
* Force ssl in production
it closes #89 
